### PR TITLE
Fix plugin source path in marketplace configuration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "ctdf",
-      "source": ".",
+      "source": "./",
       "description": "Project-agnostic task and idea management framework with 20+ built-in skills for the full development lifecycle.",
       "version": "1.0.0"
     }


### PR DESCRIPTION
## Summary
Updated the plugin source path in the marketplace configuration to use a relative path with trailing slash for consistency and proper path resolution.

## Changes
- Modified the `source` field in `.claude-plugin/marketplace.json` from `"."` to `"./"` for the ctdf plugin

## Details
This change ensures the source path is explicitly formatted as a relative directory reference with a trailing slash, which provides clearer intent and may improve compatibility with path resolution logic in the marketplace plugin system.

https://claude.ai/code/session_01NXcDscZpjjjfb1tPNzGvef