### PR TITLE
Remove hooks configuration from plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -16,6 +16,5 @@
     "release",
     "ci-cd"
   ],
-  "skills": "./skills/",
-  "hooks": "./hooks/hooks.json"
+  "skills": "./skills/"
 }


### PR DESCRIPTION
## Summary
Removed the `hooks` configuration entry from the plugin manifest file, simplifying the plugin configuration.

## Changes
- Removed the `"hooks": "./hooks/hooks.json"` line from `.claude-plugin/plugin.json`
- Kept the `skills` configuration intact

## Details
This change removes the hooks configuration reference from the plugin manifest. The hooks feature is no longer being used or configured through this plugin definition.

https://claude.ai/code/session_01CiECpohDNEsgtaVGLKHHqu