### PR TITLE
feat: git submodule support (GIT-0003)

### DIFF
--- a/scripts/analyzers/__init__.py
+++ b/scripts/analyzers/__init__.py
@@ -171,6 +171,27 @@ ROLE_PATTERNS: list[tuple[str, str]] = [
 ]
 
 
+# ── Submodule Utilities ────────────────────────────────────────────────────
+
+def detect_submodule_paths(root: Path) -> list[str]:
+    """Return list of submodule paths from .gitmodules."""
+    import configparser as _cp
+    gitmodules = root / ".gitmodules"
+    if not gitmodules.exists():
+        return []
+    cfg = _cp.ConfigParser()
+    try:
+        cfg.read(str(gitmodules), encoding="utf-8")
+    except (_cp.Error, OSError):
+        return []
+    paths = []
+    for section in cfg.sections():
+        p = cfg.get(section, "path", fallback="")
+        if p:
+            paths.append(p)
+    return paths
+
+
 # ── File System Utilities ───────────────────────────────────────────────────
 
 def load_gitignore_patterns(root: Path) -> list[str]:
@@ -206,16 +227,21 @@ def walk_source_files(
     root: Path,
     gitignore_patterns: list[str] | None = None,
     max_files: int = 5000,
+    scope_path: str | None = None,
 ) -> Generator[tuple[str, Path, str, int], None, None]:
     """Walk source files, yielding (rel_path, abs_path, extension, file_size).
 
     Skips ignored directories, binary files, and respects max_files limit.
+    If scope_path is provided, only walk files under that subdirectory
+    (e.g. a submodule path). Paths are still relative to root.
     """
     if gitignore_patterns is None:
         gitignore_patterns = load_gitignore_patterns(root)
 
+    walk_root = root / scope_path if scope_path else root
+
     count = 0
-    for dirpath, dirnames, filenames in os.walk(root):
+    for dirpath, dirnames, filenames in os.walk(walk_root):
         # Prune ignored directories
         dirnames[:] = [
             d for d in dirnames

--- a/scripts/analyzers/infrastructure.py
+++ b/scripts/analyzers/infrastructure.py
@@ -14,6 +14,7 @@ from . import (
     detect_ecosystems,
     detect_frameworks,
     detect_languages,
+    detect_submodule_paths,
     find_package_jsons,
     load_gitignore_patterns,
     make_table,
@@ -71,6 +72,37 @@ def extract_scripts(root: Path) -> dict[str, dict[str, str]]:
         if data.get("scripts"):
             rel = str(pkg_path.relative_to(root))
             results[rel] = data["scripts"]
+    return results
+
+
+# ── Git Submodule Detection ─────────────────────────────────────────────────
+
+def detect_submodules(root: Path) -> list[dict]:
+    """Detect git submodules and their configuration."""
+    import configparser as _cp
+    gitmodules = root / ".gitmodules"
+    if not gitmodules.exists():
+        return []
+    cfg = _cp.ConfigParser()
+    try:
+        cfg.read(str(gitmodules), encoding="utf-8")
+    except (_cp.Error, OSError):
+        return []
+    results = []
+    for section in cfg.sections():
+        name_match = re.match(r'^submodule\s+"(.+)"$', section)
+        name = name_match.group(1) if name_match else section
+        path = cfg.get(section, "path", fallback="")
+        url = cfg.get(section, "url", fallback="")
+        branch = cfg.get(section, "branch", fallback="")
+        initialized = (root / path / ".git").exists() if path else False
+        results.append({
+            "name": name,
+            "path": path,
+            "url": url,
+            "branch": branch or "(default)",
+            "initialized": initialized,
+        })
     return results
 
 
@@ -485,6 +517,16 @@ def generate_report(root: Path, gitignore_patterns: list[str] | None = None) -> 
     sections = []
     sections.append("# Infrastructure & Architecture Report\n")
     sections.append(f"> Auto-generated static analysis for `{root.name}`\n")
+
+    # Git Submodules
+    submodules = detect_submodules(root)
+    if submodules:
+        sections.append("## Git Submodules\n")
+        sections.append(make_table(
+            ["Name", "Path", "URL", "Branch", "Initialized"],
+            [[s["name"], s["path"], s["url"], s["branch"],
+              "Yes" if s["initialized"] else "No"] for s in submodules],
+        ))
 
     # Languages
     languages = detect_languages(root, gitignore_patterns)

--- a/scripts/skill_helper.py
+++ b/scripts/skill_helper.py
@@ -9,6 +9,7 @@ All output is JSON.  Zero external dependencies — stdlib only.
 """
 
 import argparse
+import configparser
 import json
 import os
 import re
@@ -142,6 +143,39 @@ def git_worktree_list() -> list[dict]:
     if current:
         worktrees.append(current)
     return worktrees
+
+
+# ── Submodule Detection ────────────────────────────────────────────────────
+
+def _detect_submodules(root: Path) -> list[dict]:
+    """Parse .gitmodules and return list of submodule info dicts.
+
+    Returns list of {name, path, url, branch} for each submodule.
+    """
+    gitmodules = root / ".gitmodules"
+    if not gitmodules.exists():
+        return []
+    cfg = configparser.ConfigParser()
+    try:
+        cfg.read(str(gitmodules), encoding="utf-8")
+    except (configparser.Error, OSError):
+        return []
+    submodules = []
+    for section in cfg.sections():
+        # section looks like 'submodule "name"'
+        name_match = re.match(r'^submodule\s+"(.+)"$', section)
+        name = name_match.group(1) if name_match else section
+        path = cfg.get(section, "path", fallback="")
+        url = cfg.get(section, "url", fallback="")
+        branch = cfg.get(section, "branch", fallback="")
+        if path:
+            submodules.append({
+                "name": name,
+                "path": path,
+                "url": url,
+                "branch": branch,
+            })
+    return submodules
 
 
 # ── File Helpers ────────────────────────────────────────────────────────────
@@ -398,11 +432,14 @@ def cmd_context(_args) -> dict:
     except Exception:
         wt_root = None
 
+    submodules = _detect_submodules(root)
+
     worktree = {
         "in_worktree": in_wt,
         "main_root": str(root),
         "worktree_root": str(wt_root) if in_wt and wt_root else None,
         "worktrees": [w.get("path", "") for w in wt_list],
+        "submodules": submodules,
     }
 
     # ── branches ──
@@ -890,12 +927,18 @@ def cmd_setup_task_worktree(args) -> dict:
     except subprocess.CalledProcessError as e:
         return {"success": False, "error": e.stderr.strip() or str(e)}
 
+    # Initialize submodules in the new worktree (if any)
+    submodules = _detect_submodules(root)
+    if submodules:
+        git_run("submodule", "update", "--init", "--recursive", cwd=str(wt_dir))
+
     return {
         "success": True,
         "worktree_dir": str(wt_dir),
         "branch": branch_name,
         "created": True,
         "reused_existing": False,
+        "submodules_initialized": len(submodules) > 0,
     }
 
 
@@ -1002,6 +1045,21 @@ def cmd_status_report(_args) -> dict:
 
 
 # ════════════════════════════════════════════════════════════════════════════
+# Subcommand: list-submodules
+# ════════════════════════════════════════════════════════════════════════════
+
+def cmd_list_submodules(_args) -> dict:
+    """Return detected submodules for the current project."""
+    root = get_main_repo_root()
+    submodules = _detect_submodules(root)
+    return {
+        "has_submodules": len(submodules) > 0,
+        "count": len(submodules),
+        "submodules": submodules,
+    }
+
+
+# ════════════════════════════════════════════════════════════════════════════
 # Subcommand: detect-release-config
 # ════════════════════════════════════════════════════════════════════════════
 
@@ -1104,6 +1162,9 @@ def main():
     # status-report
     sub.add_parser("status-report", help="Return pre-computed task status data")
 
+    # list-submodules
+    sub.add_parser("list-submodules", help="Return detected git submodules")
+
     # detect-release-config
     sub.add_parser("detect-release-config", help="Return all release configuration")
 
@@ -1119,6 +1180,7 @@ def main():
         "create-project-files": cmd_create_project_files,
         "detect-branch-strategy": cmd_detect_branch_strategy,
         "setup-task-worktree": cmd_setup_task_worktree,
+        "list-submodules": cmd_list_submodules,
         "status-report": cmd_status_report,
         "detect-release-config": cmd_detect_release_config,
     }

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -33,6 +33,13 @@ Run both and parse JSON:
 
 Use `CTX.config.*` for branch names, tag prefix, verify command — never re-read CLAUDE.md manually.
 
+### Submodule Awareness
+
+When `SH context` returns `worktree.submodules` with entries, the project uses git submodules. During the release pipeline:
+- **Stage 5 (Merge to Staging)** and **Stage 7 (Merge to Main)**: After merge, run `git submodule update --init --recursive` to ensure submodules are at the correct commits
+- **Stage 7d (Version Bump)**: Check for version-bearing files in submodule paths as well
+- Submodule pointers are part of the commit tree — merges automatically carry the correct submodule references
+
 ## Arguments
 
 `SH dispatch --skill release --args "$ARGUMENTS"`

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -21,6 +21,13 @@ Always respond and work in English.
 | `SH`  | `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/skill_helper.py` |
 | `PM`  | `TM platform-cmd` |
 
+### Submodule Awareness
+
+When `SH context` returns `worktree.submodules` with entries, the project uses git submodules. The setup skill should:
+- Detect and report submodules during project analysis (`SH list-submodules`)
+- Allow the user to choose which submodule to configure if running `/setup env` on a submodule project
+- Apply CLAUDE.md and branch configuration to the selected submodule's repository context
+
 ## Arguments
 
 The user invoked with: **$ARGUMENTS**

--- a/skills/task/SKILL.md
+++ b/skills/task/SKILL.md
@@ -20,11 +20,22 @@ You are a task manager for this project. Manage the full task lifecycle: picking
 
 ## Skill Context
 
-`SH context` → platform config, worktree state, branch config, release config as JSON. Use throughout.
+`SH context` → platform config, worktree state (including `submodules` list), branch config, release config as JSON. Use throughout.
 
 `PM <operation> [key=value ...]` — operations: `list-issues`, `search-issues`, `view-issue`, `edit-issue`, `close-issue`, `comment-issue`, `create-issue`, `create-pr`, `list-pr`, `merge-pr`, `create-release`, `edit-release`.
 
 Task files (`to-do.txt`, `progressing.txt`, `done.txt`) always live in `main_root`. Source code lives in the worktree directory.
+
+### Submodule Awareness
+
+When `SH context` returns `worktree.submodules` with one or more entries, the project uses git submodules. Before creating a worktree or exploring the codebase:
+
+1. Run `SH list-submodules` to get available submodules
+2. Present an `AskUserQuestion` with options: each submodule name + "Root repository (parent)"
+3. If a submodule is selected, all codebase exploration and implementation operates within `<worktree_dir>/<submodule_path>` — never on the parent repo directly
+4. After task completion (Step 6), if a submodule was selected: `git add <submodule_path> && git commit -m "chore: update submodule <name> pointer"` in the parent repo to align the submodule reference
+
+Submodules are automatically initialized (`git submodule update --init --recursive`) when worktrees are created.
 
 ## Argument Dispatch
 


### PR DESCRIPTION
## Summary
- Added git submodule detection via `.gitmodules` parsing to `skill_helper.py`
- Extended `SH context` to include `worktree.submodules` list
- Worktrees now auto-initialize submodules with `git submodule update --init --recursive`
- Added `SH list-submodules` subcommand for skill use
- Infrastructure analyzer now reports submodule configuration
- Updated task, setup, and release skill docs with submodule-aware behavior

Closes #13

## Test plan
- [ ] Run `SH list-submodules` in a repo with/without submodules
- [ ] Verify `SH context` includes submodules field
- [ ] Create a worktree in a repo with submodules and confirm initialization
- [ ] Run infrastructure analysis and verify submodule table appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)