### PR TITLE
feat: add /help skill (HELP-0004)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ctdf",
   "version": "3.2.0",
-  "description": "Project-agnostic task and release management framework with 6 streamlined skills: /task, /idea, /release, /docs, /setup, /update. Features a gated release pipeline with automatic subagent orchestration.",
+  "description": "Project-agnostic task and release management framework with 8 streamlined skills: /task, /idea, /release, /docs, /setup, /update, /tests, /help. Features a gated release pipeline with automatic subagent orchestration.",
   "author": {
     "name": "dnviti"
   },

--- a/scripts/skill_helper.py
+++ b/scripts/skill_helper.py
@@ -660,6 +660,13 @@ def dispatch_docs(parts: list[str]) -> dict:
         return {**base, "flow": "generate", "remaining_args": " ".join(parts)}
 
 
+def dispatch_help(parts: list[str]) -> dict:
+    """Dispatch for the help skill."""
+    if not parts:
+        return {"flow": "overview", "task_code": "", "remaining_args": ""}
+    return {"flow": "query", "task_code": "", "remaining_args": " ".join(parts)}
+
+
 DISPATCHERS = {
     "task": dispatch_task,
     "idea": dispatch_idea,
@@ -668,6 +675,7 @@ DISPATCHERS = {
     "release-start": dispatch_release,  # backward compat
     "update": dispatch_update,
     "docs": dispatch_docs,
+    "help": dispatch_help,
 }
 
 

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: help
+description: "Interactive skill framework guide. Shows all available skills and their usage, or explains a specific topic when given a query."
+disable-model-invocation: true
+argument-hint: "[query]"
+---
+
+# Help Guide
+
+You are a help assistant for the CTDF plugin. Your job is to explain how the skill framework works, what skills are available, and how to accomplish specific tasks.
+
+Always respond and work in English.
+
+## Shorthand
+
+| Alias | Expands to |
+|-------|------------|
+| `SH`  | `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/skill_helper.py` |
+
+## Arguments
+
+`SH dispatch --skill help --args "$ARGUMENTS"`
+
+Returns `flow`:
+- **`"overview"`** — No arguments provided. Show the full help page.
+- **`"query"`** — User provided a question. Explain the relevant skill(s).
+
+---
+
+## Overview Flow
+
+When invoked with no arguments (`/help`), present a complete guide to the framework.
+
+### Step 1: Gather skill metadata
+
+Read the YAML frontmatter (between `---` markers) from each `skills/*/SKILL.md` file to extract `name`, `description`, and `argument-hint`. Also read `.claude-plugin/plugin.json` for the framework version.
+
+### Step 2: Present the help page
+
+Render the following sections:
+
+---
+
+**CTDF — Claude Task Development Framework**
+
+> Version: (from plugin.json) | Skills: (count)
+
+### Available Skills
+
+| Skill | Description | Usage |
+|-------|-------------|-------|
+| `/task` | (description from frontmatter) | `/task [argument-hint]` |
+| `/idea` | ... | ... |
+| ... | ... | ... |
+
+### Quick Start
+
+1. **Set up your project:** `/setup` — Initialize task files, branch strategy, and platform integration
+2. **Brainstorm ideas:** `/idea create [description]` — Capture ideas for later evaluation
+3. **Approve ideas into tasks:** `/idea approve [IDEA-CODE]` — Promote an idea to a task with full technical details
+4. **Create tasks directly:** `/task create [description]` — Create a fully specified task
+5. **Pick up a task:** `/task pick [CODE]` — Start implementing a task in an isolated worktree
+6. **Continue work:** `/task continue [CODE]` — Resume an in-progress task
+7. **Check status:** `/task status` — See all tasks, progress, and recommendations
+8. **Run tests:** `/tests scout` — Find coverage gaps; `/tests create [target]` — Generate tests
+9. **Release:** `/release create X.X.X` then `/release continue X.X.X` — Run the 9-stage release pipeline
+10. **Generate docs:** `/docs generate` — Produce technical documentation
+
+### Task Lifecycle
+
+```
+/idea create → /idea approve → /task pick → implement → /task pick (close) → /release
+```
+
+Ideas flow through approval into tasks. Tasks are picked up, implemented in isolated worktrees, tested, and closed. The release pipeline collects completed tasks, merges through staging, and tags a production release.
+
+### Modes
+
+CTDF supports three operating modes for task tracking:
+- **Local-only** — Tasks in text files (`to-do.txt`, `progressing.txt`, `done.txt`)
+- **Platform-only** — Tasks as GitHub/GitLab issues (no local files)
+- **Dual sync** — Local files synced with platform issues
+
+Configure via `.claude/issues-tracker.json`.
+
+### Tips
+
+- Add `yolo` to any command to auto-approve all gates: `/task pick all yolo`
+- Use `/task pick all` to implement all pending release tasks in parallel via subagents
+- Use `/release resume` to continue a release pipeline from where it left off
+- Run `/setup env` to regenerate CLAUDE.md after changing your project structure
+
+---
+
+## Query Flow
+
+When invoked with a query (`/help how do I create a task`), provide a targeted explanation.
+
+### Step 1: Parse the query
+
+Extract the user's question from the dispatch `remaining_args`.
+
+### Step 2: Match against skills
+
+Compare the query keywords against:
+- Skill names: task, idea, release, setup, docs, update, tests, help
+- Flow names: pick, create, continue, status, scout, approve, generate, sync
+- Concepts: worktree, submodule, yolo, pipeline, staging, branch, milestone
+
+### Step 3: Explain
+
+Provide a concise, actionable answer that includes:
+1. **Which skill to use** — name and brief description
+2. **Exact command syntax** — the specific `/skill subcommand [args]` to run
+3. **What it does** — brief explanation of the flow that will execute
+4. **Example** — one concrete usage example
+
+If the query matches multiple skills, explain how they relate (e.g., ideas become tasks, tasks feed into releases).
+
+If the query doesn't match any skill, suggest the closest match and offer to show the full overview with `/help`.
+
+---
+
+## Important Rules
+
+1. **Read-only** — This skill never modifies any files.
+2. **Dynamic** — Always read current skill frontmatter; never hardcode skill lists.
+3. **Concise** — Keep explanations focused and actionable.
+4. **Accurate** — Use exact command syntax from skill argument-hints.


### PR DESCRIPTION
## Summary
- New `/help` skill with overview and query flows
- `/help` (no args) shows complete framework guide with all skills, quick start, lifecycle diagram
- `/help <query>` provides contextual explanation matched to relevant skills
- Added `dispatch_help` to `skill_helper.py`
- Updated `plugin.json` to 8 skills

Closes #15

## Test plan
- [ ] Run `/help` and verify overview renders with all skills
- [ ] Run `/help how do I create a task` and verify targeted response
- [ ] Verify `dispatch --skill help` returns correct flow routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)