### PR TITLE
chore(release): bump plugin version to v3.5.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "ctdf",
       "source": "./",
       "description": "Project-agnostic task and release management framework with 8 streamlined skills and a gated release pipeline with automatic subagent orchestration.",
-      "version": "3.4.5"
+      "version": "3.5.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ctdf",
-  "version": "3.4.6",
+  "version": "3.5.0",
   "description": "Project-agnostic task and release management framework with 8 streamlined skills: /task, /idea, /release, /docs, /setup, /update, /tests, /help. Features a gated release pipeline with automatic subagent orchestration.",
   "author": {
     "name": "dnviti"


### PR DESCRIPTION
Bumps .claude-plugin/plugin.json and marketplace.json to v3.5.0.