### PR TITLE
feat: opt-in vector memory MCP with seamless setup installation (VMEM-0029)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 dist/
 .claude/memory/
 .claude/worktrees/
+.mcp.json

--- a/config/mcp-server.example.json
+++ b/config/mcp-server.example.json
@@ -17,7 +17,7 @@
     "_comment": "Vector memory MCP is opt-in. Enable via /setup for automatic installation.",
     "enabled": false,
     "transport": "stdio",
-    "auto_start": true,
+    "auto_start": false,
     "restart_on_crash": true,
     "tools": [
       {

--- a/config/project-config.example.json
+++ b/config/project-config.example.json
@@ -41,7 +41,7 @@
     "enabled": false,
     "transport": "stdio",
     "auto_start": false,
-    "_comment": "Vector memory MCP is opt-in. Enable via /setup. Requires: pip install mcp lancedb sentence-transformers"
+    "_comment": "Vector memory MCP is opt-in. Enable via /setup. Requires: pip install \"mcp>=1.0\" \"lancedb>=0.5.0,<1.0\" \"sentence-transformers>=2.7.0,<3.0\""
   },
   "social_announce": {
     "platforms": {

--- a/scripts/mcp_server.py
+++ b/scripts/mcp_server.py
@@ -170,7 +170,7 @@ Configure your MCP client to launch this script as a subprocess.
             print(json.dumps({
                 "mcp_sdk": False,
                 "status": "error",
-                "install": "pip install mcp",
+                "install": 'pip install "mcp>=1.0" "lancedb>=0.5.0,<1.0" "sentence-transformers>=2.7.0,<3.0"',
             }))
             sys.exit(1)
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -314,6 +314,9 @@ grep -qxF '.claude/memory/' .gitignore 2>/dev/null || echo '.claude/memory/' >> 
 
 # Append .claude/worktrees/ if not already present
 grep -qxF '.claude/worktrees/' .gitignore 2>/dev/null || echo '.claude/worktrees/' >> .gitignore
+
+# Append .mcp.json if not already present (contains machine-specific absolute paths)
+grep -qxF '.mcp.json' .gitignore 2>/dev/null || echo '.mcp.json' >> .gitignore
 ```
 
 **9.7b. GATE — ask the user:**


### PR DESCRIPTION
## Summary

- Reverses vector memory MCP from mandatory/always-on to **disabled by default, opt-in during `/setup`**
- Setup Step 9.7 now presents a GATE asking the user whether to enable vector memory MCP
- When enabled: full automated install (all Python packages, config update, `.mcp.json` generation at repo root, index build, verification)
- `.gitignore` hardened unconditionally with `.claude/memory/` and `.claude/worktrees/` entries

Closes #104

## Test plan

- [ ] Verify `config/project-config.example.json` defaults are all `false` for vector memory and MCP
- [ ] Verify `.gitignore` contains `.claude/memory/` and `.claude/worktrees/`
- [ ] Verify `scripts/mcp_server.py` error message lists all 3 packages
- [ ] Verify `skills/setup/SKILL.md` Step 9.7 has opt-in GATE and automated install sequence
- [ ] Run `/setup` and verify vector memory MCP GATE appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)