### PR TITLE
fix: enable Ollama tool call offloading with 0-10 level control (OLLAM-0030)

### DIFF
--- a/config/ollama-config.example.json
+++ b/config/ollama-config.example.json
@@ -21,7 +21,7 @@
       "variable-naming"
     ],
     "tool_calls": {
-      "enabled": false,
+      "enabled": true,
       "include_tools": ["Bash", "Read", "Grep", "Glob", "Edit", "Write"],
       "exclude_patterns": [
         "git push",

--- a/config/project-config.example.json
+++ b/config/project-config.example.json
@@ -88,7 +88,6 @@
   "ollama": {
     "enabled": false,
     "model": "",
-    "offloading": false,
     "offloading_level": 5
   }
 }

--- a/scripts/hooks/pre_tool_offload.py
+++ b/scripts/hooks/pre_tool_offload.py
@@ -80,11 +80,15 @@ def _load_config() -> dict:
 
 
 def _tool_calls_enabled(config: dict, tool_name: str) -> bool:
-    """Check whether tool call offloading is enabled for the given tool."""
+    """Check whether tool call offloading is enabled for the given tool.
+
+    Defaults to True when tool_calls section is absent or 'enabled' is not set,
+    so the offloading level (0-10) becomes the single control point.
+    """
     offloading_cfg = config.get("offloading", {})
     tool_calls_cfg = offloading_cfg.get("tool_calls", {})
 
-    if not tool_calls_cfg.get("enabled", False):
+    if not tool_calls_cfg.get("enabled", True):
         return False
 
     include_tools = tool_calls_cfg.get("include_tools", [])

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -259,11 +259,26 @@ STOP.
    python3 ${CLAUDE_PLUGIN_ROOT}/scripts/ollama_manager.py pull-model --name <MODEL_NAME>
    ```
 
-6. Ask about task offloading:
+6. Ask about offloading level:
+
+   Present the offloading scale:
+   > **Offloading Level (0-10):** Controls how aggressively tool calls are routed to the local Ollama model instead of the cloud.
+   >
+   > | Level | Behavior |
+   > |-------|----------|
+   > | 0 | Never offload — all tool calls go to the cloud |
+   > | 1-2 | Minimal — only trivial operations |
+   > | 3-4 | Light — simple bash commands (ls, cat, git status) |
+   > | 5 | Moderate (default) — simple commands + short edits |
+   > | 6-7 | Aggressive — includes read/grep/glob + complex bash |
+   > | 8-9 | Very aggressive — includes structural edits |
+   > | 10 | Always — all tool calls go to Ollama (except destructive commands) |
 
    Use `AskUserQuestion`:
-   - **"Enable automatic offloading (Claude routes simple tasks to Ollama)"**
-   - **"Manual only (I will decide when to use Ollama)"**
+   - **"Level 5 — Moderate (recommended)"** — good balance of token savings and quality
+   - **"Level 3 — Light"** — conservative, only simple commands
+   - **"Level 8 — Very aggressive"** — maximum token savings, requires capable local model
+   - **"Level 0 — Disabled"** — no offloading, all tool calls go to the cloud
 
    STOP.
 
@@ -272,7 +287,18 @@ STOP.
    mkdir -p .claude
    cp ${CLAUDE_PLUGIN_ROOT}/config/ollama-config.example.json .claude/ollama-config.json
    ```
-   Update `.claude/ollama-config.json` with: `enabled: true`, detected hardware values, selected model, offloading preference.
+   Update `.claude/ollama-config.json` with:
+   - `enabled: true`
+   - `model`: selected model name
+   - `hardware`: detected hardware values
+   - `offloading.level`: chosen level (0-10)
+   - `offloading.tool_calls.enabled: true` (so the level controls routing)
+   - `offloading.tool_calls.include_tools`: `["Bash", "Read", "Grep", "Glob", "Edit", "Write"]`
+
+   Also update `.claude/project-config.json`:
+   - `ollama.enabled: true`
+   - `ollama.model`: selected model name
+   - `ollama.offloading_level`: chosen level (0-10)
 
 Then return here for Step 9.7.
 


### PR DESCRIPTION
## Summary

- Fixed Ollama tool call offloading that was never triggered due to `tool_calls.enabled: false` at every config level
- Made offloading level (0-10) the single control point: 0=never, 10=always (except destructive commands)
- Removed redundant `offloading: false` boolean from project-config — `offloading_level` is the sole control
- Setup skill now presents a 0-10 level selector with clear descriptions instead of a binary enable/disable

Closes #106

## Test plan

- [ ] Verify `ollama-config.example.json` has `tool_calls.enabled: true`
- [ ] Verify `project-config.example.json` has no `offloading: false` boolean
- [ ] Verify `pre_tool_offload.py` defaults `tool_calls.enabled` to `True`
- [ ] Verify setup SKILL.md Step 9.5.6 has 0-10 level selector
- [ ] Test: config with `level: 5` and no `tool_calls.enabled` field → tool calls should route to Ollama

🤖 Generated with [Claude Code](https://claude.com/claude-code)