### PR TITLE
fix: disable agent worktree isolation when worktrees disabled (FIX-0049)

### DIFF
--- a/skills/task/SKILL.md
+++ b/skills/task/SKILL.md
@@ -337,6 +337,8 @@ Present: "Found **N pending tasks** for release X.X.X. **M can run in parallel**
 
 #### Step 3a: Parallel execution (default)
 
+**Worktree guard:** Before spawning parallel agents, check `SH context` → `worktree` data. If `worktrees.enabled` is `false` in the project config (the default), **skip this step entirely** and fall through to **Step 3b** (sequential execution). Log: "Worktrees are disabled — using sequential execution on the shared release branch." This is required because `isolation: "worktree"` creates `.claude/worktrees/agent-*/` directories, violating the user's worktree-disabled configuration. Without isolation, parallel agents would conflict on the shared branch.
+
 For each batch, spawn Agent subagents with `isolation: "worktree"` and `mode: "bypassPermissions"`:
 
 ```
@@ -528,6 +530,8 @@ GATE: "Create tasks from all ideas" / "Cancel"
 
 #### Step 2a: Parallel execution (default)
 
+**Worktree guard:** Before spawning parallel agents, check `SH context` → `worktree` data. If `worktrees.enabled` is `false` in the project config (the default), **skip this step entirely** and fall through to **Step 2b** (sequential execution). Log: "Worktrees are disabled — using sequential execution on the shared release branch." This prevents `isolation: "worktree"` from creating `.claude/worktrees/agent-*/` directories when the user has disabled worktrees.
+
 For each idea, spawn Agent subagents with `isolation: "worktree"` and `mode: "bypassPermissions"`:
 
 ```
@@ -650,6 +654,8 @@ Present: "Found **N in-progress tasks** to continue."
 GATE: "Spawn agents to continue all tasks" / "Cancel"
 
 #### Step 2a: Parallel execution (default)
+
+**Worktree guard:** Before spawning parallel agents, check `SH context` → `worktree` data. If `worktrees.enabled` is `false` in the project config (the default), **skip this step entirely** and fall through to **Step 2b** (sequential execution). Log: "Worktrees are disabled — using sequential execution on the shared release branch." This prevents `isolation: "worktree"` from creating `.claude/worktrees/agent-*/` directories when the user has disabled worktrees.
 
 For each in-progress task, spawn Agent subagents with `isolation: "worktree"` and `mode: "bypassPermissions"`:
 


### PR DESCRIPTION
## Summary
- Add **worktree guard** to Pick All (Step 3a), Create All (Step 2a), and Continue All (Step 2a) in `skills/task/SKILL.md`
- When `worktrees.enabled` is `false`, forces sequential execution instead of spawning agents with `isolation: "worktree"`
- Prevents `.claude/worktrees/agent-*/` directory creation that violates the user's worktree-disabled configuration

Closes #190

## Test plan
- [ ] Verify `/task pick all` uses sequential execution when worktrees disabled
- [ ] Verify `/task create all` falls through to sequential when worktrees disabled
- [ ] Verify `/task continue all` falls through to sequential when worktrees disabled
- [ ] Verify parallel execution still works when worktrees enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)