### PR TITLE
fix: remove invalid PrePush hook event

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,16 +1,5 @@
 {
   "hooks": {
-    "PrePush": [
-      {
-        "matcher": ".*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/quality_gate.py --root . --verify-command \"${VERIFY_COMMAND}\" --json"
-          }
-        ]
-      }
-    ],
     "PreToolUse": [
       {
         "matcher": "Bash|Read|Grep|Glob|Edit|Write",


### PR DESCRIPTION
## Summary
- Remove invalid `PrePush` hook event from `hooks/hooks.json` that caused plugin load failure
- `PrePush` is not a recognized Claude Code hook event — only the events listed in the schema are valid

## Test plan
- [x] Verify hooks.json is valid after removal
- [ ] Confirm plugin loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)